### PR TITLE
Mount broker configmaps as directories instead of using subpath (SC-2393)

### DIFF
--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.25.0"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster-helm
 type: application
-version: 0.1.0-SNAPSHOT
+version: 0.1.1
 icon: https://zeebe.io/img/zeebe-logo.png
 dependencies:
 - name: elasticsearch

--- a/charts/zeebe-cluster-helm/templates/configmap.yaml
+++ b/charts/zeebe-cluster-helm/templates/configmap.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 metadata:
-  name: {{ include "zeebe-cluster.fullname" . }}
-  labels: 
+  name: {{ include "zeebe-cluster.fullname" . }}-startup
+  labels:
     {{- include "zeebe-cluster.labels" . | nindent 4 }}
 apiVersion: v1
 data:
@@ -25,30 +25,44 @@ data:
 
       export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS="${contactPoints}"
     fi
-    
+
     if [ "$(ls -A /exporters/)" ]; then
       mkdir /usr/local/zeebe/exporters/
       cp -a /exporters/*.jar /usr/local/zeebe/exporters/
-    else  
+    else
       echo "No exporters available."
     fi
 
     exec /usr/local/zeebe/bin/broker
-
-  application.yaml: |
+---
+{{- if or .Values.zeebeCfg .Values.log4j2 }}
+kind: ConfigMap
+metadata:
+  name: {{ include "zeebe-cluster.fullname" . }}-broker
+  labels:
+    {{- include "zeebe-cluster.labels" . | nindent 4 }}
+apiVersion: v1
+data:
 {{- if .Values.zeebeCfg }}
+  application.yaml: |
 {{- with .Values.zeebeCfg }}
 {{ . | toYaml | indent 4 }}
 {{- end }}
 {{- end }}
-
-  broker-log4j2.xml: |
 {{- if .Values.log4j2 }}
+  log4j2.xml: |
     {{ .Values.log4j2 | indent 4 | trim }}
 {{- end }}
-
-  gateway-log4j2.xml: |
+{{- end }}
+---
 {{- if .Values.gateway.log4j2 }}
+kind: ConfigMap
+metadata:
+  name: {{ include "zeebe-cluster.fullname" . }}-gateway
+  labels:
+    {{- include "zeebe-cluster.labels" . | nindent 4 }}
+apiVersion: v1
+data:
+  log4j2.xml: |
     {{ .Values.gateway.log4j2 | indent 4 | trim }}
 {{- end }}
-

--- a/charts/zeebe-cluster-helm/templates/configmap.yaml
+++ b/charts/zeebe-cluster-helm/templates/configmap.yaml
@@ -33,6 +33,10 @@ data:
       echo "No exporters available."
     fi
 
+    if [ "$(ls -A /usr/local/zeebe/configmaps/)" ]; then
+      cp -LRp /usr/local/zeebe/configmaps/* /usr/local/zeebe/config/
+    fi
+
     exec /usr/local/zeebe/bin/broker
 ---
 {{- if or .Values.zeebeCfg .Values.log4j2 }}

--- a/charts/zeebe-cluster-helm/templates/configmap.yaml
+++ b/charts/zeebe-cluster-helm/templates/configmap.yaml
@@ -38,6 +38,10 @@ data:
     fi
 
     exec /usr/local/zeebe/bin/broker
+
+  docker-java-home: |
+    #/bin/sh
+    echo "$JAVA_HOME"
 ---
 {{- if or .Values.zeebeCfg .Values.log4j2 }}
 kind: ConfigMap

--- a/charts/zeebe-cluster-helm/templates/gateway-deployment.yaml
+++ b/charts/zeebe-cluster-helm/templates/gateway-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             {{- end }}
           volumeMounts:
             {{- if .Values.gateway.log4j2 }}
-            - name: config
+            - name: config-gateway
               mountPath: /usr/local/zeebe/config/log4j2.xml
               subPath: gateway-log4j2.xml
             {{- end }}
@@ -86,10 +86,12 @@ spec:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
           {{- end }}
       volumes:
-        - name: config
+        {{- if .Values.gateway.log4j2 }}
+        - name: config-gateway
           configMap:
-            name: {{ include "zeebe-cluster.fullname" . }}
+            name: {{ include "zeebe-cluster.fullname" . }}-gateway
             defaultMode: 0744
+        {{- end }}
 {{- with .Values.gateway.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/zeebe-cluster-helm/templates/statefulset.yaml
+++ b/charts/zeebe-cluster-helm/templates/statefulset.yaml
@@ -101,7 +101,7 @@ spec:
         volumeMounts:
         {{- if or .Values.zeebeCfg .Values.log4j2 }}
         - name: config-broker
-          mountPath: /usr/local/zeebe/config
+          mountPath: /usr/local/zeebe/configmaps
         {{- end }}
         - name: config-startup
           mountPath: /usr/local/bin

--- a/charts/zeebe-cluster-helm/templates/statefulset.yaml
+++ b/charts/zeebe-cluster-helm/templates/statefulset.yaml
@@ -99,27 +99,28 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
-        - name: config
-          mountPath: /usr/local/zeebe/config/application.yaml
-          subPath: application.yaml
-        - name: config
-          mountPath: /usr/local/bin/startup.sh
-          subPath: startup.sh
+        {{- if or .Values.zeebeCfg .Values.log4j2 }}
+        - name: config-broker
+          mountPath: /usr/local/zeebe/config
+        {{- end }}
+        - name: config-startup
+          mountPath: /usr/local/bin
         - name: data
           mountPath: /usr/local/zeebe/data
         - name: exporters
           mountPath: /exporters
-        {{- if .Values.log4j2 }}
-        - name: config
-          mountPath: /usr/local/zeebe/config/log4j2.xml
-          subPath: broker-log4j2.xml
-        {{- end }}
         securityContext:
           {{ toYaml .Values.podSecurityContext | indent 12 | trim }}
       volumes:
-      - name: config
+        {{- if or .Values.zeebeCfg .Values.log4j2 }}
+      - name: config-broker
         configMap:
-          name: {{ include "zeebe-cluster.fullname" . }}
+          name: {{ include "zeebe-cluster.fullname" . }}-broker
+          defaultMode: 0744
+        {{- end }}
+      - name: config-startup
+        configMap:
+          name: {{ include "zeebe-cluster.fullname" . }}-startup
           defaultMode: 0744
       - name: exporters
         emptyDir: {}    


### PR DESCRIPTION
Due to a Kubernetes bug (https://github.com/kubernetes/kubernetes/issues/68211) we periodically have to  intervene when a Zeebe broker crashes and can't successfully restart on its own. This is related to using subpaths to mount config volumes.

To avoid this, switch away from using subpath and instead mount configmaps as directories. Because this overwrites existing directories*, we have to mount the broker configuration to a temp directory and copy the files over at startup.

[*] This behavior is why the [previous approach](https://github.com/ezcater/zeebe-kubernetes/pull/63) generated so many logs - it deleted the built-in log4j2.xml. Now that doesn't happen!

## Caveats
This PR only partially addresses the configmap issue:
 
- Gateway pods will still use subpath if the log4j2 configmap is customized. To make this work fully I'd need to add similar startup logic so that files could be copied. We don't customize the gateway so it doesn't seem necessary right now.

This fix is also rather inelegant - I'd prefer to treat this as a temporary shim until subpaths are fixed in Kubernetes, instead of trying to contribute it to upstream. Happy to be convinced otherwise though!