### PR TITLE
Add a liveness probe on `/health` endpoint

### DIFF
--- a/charts/zeebe-cluster-helm/templates/statefulset.yaml
+++ b/charts/zeebe-cluster-helm/templates/statefulset.yaml
@@ -89,9 +89,17 @@ spec:
           name: {{ default "command" .Values.serviceCommandName  }}
         - containerPort: {{ .Values.serviceInternalPort  }}
           name: {{ default "internal" .Values.serviceInternalName  }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.livenessProbe.probePath }}
+            port: {{ .Values.serviceHttpPort }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.probePath }}
+            path: {{ .Values.readinessProbe.probePath }}
             port: {{ .Values.serviceHttpPort }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -67,10 +67,17 @@ resources:
   limits:
     cpu: 1000m
     memory: 4Gi
-probePath: /ready
+livenessProbe:
+  failureThreshold: 5
+  periodSeconds: 60
+  probePath: /health
+  successThreshold: 1
+  timeoutSeconds: 1
+  initialDelaySeconds: 3600
 readinessProbe:
   failureThreshold: 1
   periodSeconds: 10
+  probePath: /ready
   successThreshold: 1
   timeoutSeconds: 1
 podDisruptionBudget:


### PR DESCRIPTION
When Zeebe broker partitions are unhealthy for [15 minutes or more](https://app.datadoghq.com/monitors/21700120), we currently page the OMS rotation. The on-call engineer's only two recourses are to wait or to restart the unhealthy broker, and by and large the answer will always be to restart the broker. This PR aims to automate that work and prevent those pages.

<strike>Quick Kubernetes sidenote: because we have a [`PodDisruptionBudget`](https://github.com/ezcater/zeebe-cluster-helm/blob/main/charts/zeebe-cluster-helm/templates/poddisruptionbudget.yaml) that specifies a `maxUnavailable` of 1, I think this should be safe even if we have multiple pods reporting as unhealthy at once.</strike> EDIT: See [Crystal's comment](https://github.com/ezcater/zeebe-cluster-helm/pull/3#discussion_r658257138) below.