### PR TITLE
Add the ability to specify a PodSecurityPolicy

### DIFF
--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0.0"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster
 type: application
-version: 0.1.3
+version: 0.2.0
 icon: https://zeebe.io/img/zeebe-logo.png
 dependencies:
 - name: elasticsearch

--- a/charts/zeebe-cluster-helm/templates/gateway-deployment.yaml
+++ b/charts/zeebe-cluster-helm/templates/gateway-deployment.yaml
@@ -75,7 +75,7 @@ spec:
               subPath: gateway-log4j2.xml
             {{- end }}
           securityContext:
-            {{ toYaml .Values.podSecurityContext | indent 12 | trim }}
+            {{ toYaml .Values.gateway.podSecurityContext | indent 12 | trim }}
           readinessProbe:
             tcpSocket:
               port: {{ default "gateway" .Values.serviceGatewayName  }}
@@ -102,5 +102,12 @@ spec:
 {{- end }}
 {{- with .Values.gateway.tolerations }}
       tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.gateway.serviceAccount.create}}
+      serviceAccountName: {{ include "zeebe-cluster.names.gateway" . }}
+{{- end }}
+{{- with .Values.gateway.securityContext }}
+      securityContext:
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/zeebe-cluster-helm/templates/gateway-podsecuritypolicy.yaml
+++ b/charts/zeebe-cluster-helm/templates/gateway-podsecuritypolicy.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.gateway.rbac.enabled .Values.gateway.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "zeebe-cluster.names.gateway" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    {{- if eq (int .Values.gateway.securityContext.runAsUser) 0 }}
+    rule: 'RunAsAny'
+    {{- else }}
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.gateway.securityContext.runAsUser }}
+        max: {{ .Values.gateway.securityContext.runAsUser }}
+    {{- end }}
+  runAsGroup:
+    {{- if eq (int .Values.gateway.securityContext.runAsGroup) 0 }}
+    rule: 'RunAsAny'
+    {{- else }}
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.gateway.securityContext.runAsGroup }}
+        max: {{ .Values.gateway.securityContext.runAsGroup }}
+    {{- end }}
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    {{- if eq (int .Values.gateway.securityContext.fsGroup) 0 }}
+    rule: 'RunAsAny'
+    {{- else }}
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.gateway.securityContext.fsGroup }}
+        max: {{ .Values.gateway.securityContext.fsGroup }}
+    {{- end }}
+  readOnlyRootFilesystem: {{ .Values.gateway.podSecurityContext.readOnlyRootFilesystem | default false }}
+  {{- end }}

--- a/charts/zeebe-cluster-helm/templates/gateway-role.yaml
+++ b/charts/zeebe-cluster-helm/templates/gateway-role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.gateway.rbac.enabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "zeebe-cluster.names.gateway" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
+  annotations:
+    {{- toYaml  .Values.annotations | nindent 4 }}
+rules:
+{{- if .Values.gateway.rbac.pspEnabled }}
+  - apiGroups:
+      - extensions
+    resourceNames:
+      - {{ include "zeebe-cluster.names.gateway" . }}
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+{{- end -}}
+{{- end -}}

--- a/charts/zeebe-cluster-helm/templates/gateway-rolebinding.yaml
+++ b/charts/zeebe-cluster-helm/templates/gateway-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.gateway.rbac.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "zeebe-cluster.names.gateway" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
+  annotations:
+    {{- toYaml  .Values.annotations | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "zeebe-cluster.names.gateway" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "zeebe-cluster.names.gateway" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/zeebe-cluster-helm/templates/gateway-serviceaccount.yaml
+++ b/charts/zeebe-cluster-helm/templates/gateway-serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.gateway.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "zeebe-cluster.names.gateway" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
+  annotations:
+    {{- toYaml  .Values.annotations | nindent 4 }}
+{{- end -}}

--- a/charts/zeebe-cluster-helm/templates/podsecuritypolicy.yaml
+++ b/charts/zeebe-cluster-helm/templates/podsecuritypolicy.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.rbac.enabled .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "zeebe-cluster.names.broker" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    {{- if eq (int .Values.securityContext.runAsUser) 0 }}
+    rule: 'RunAsAny'
+    {{- else }}
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.runAsUser }}
+        max: {{ .Values.securityContext.runAsUser }}
+    {{- end }}
+  runAsGroup:
+    {{- if eq (int .Values.securityContext.runAsGroup) 0 }}
+    rule: 'RunAsAny'
+    {{- else }}
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.runAsGroup }}
+        max: {{ .Values.securityContext.runAsGroup }}
+    {{- end }}
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    {{- if eq (int .Values.securityContext.fsGroup) 0 }}
+    rule: 'RunAsAny'
+    {{- else }}
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.fsGroup }}
+        max: {{ .Values.securityContext.fsGroup }}
+    {{- end }}
+  readOnlyRootFilesystem: {{ .Values.podSecurityContext.readOnlyRootFilesystem | default false }}
+  {{- end }}

--- a/charts/zeebe-cluster-helm/templates/role.yaml
+++ b/charts/zeebe-cluster-helm/templates/role.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rbac.enabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "zeebe-cluster.names.broker" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
+  annotations:
+    {{- toYaml  .Values.annotations | nindent 4 }}
+rules:
+{{- if .Values.rbac.pspEnabled }}
+  - apiGroups:
+      - extensions
+    resourceNames:
+      - {{ include "zeebe-cluster.names.broker" . }}
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+{{- end -}}
+{{- end -}}

--- a/charts/zeebe-cluster-helm/templates/rolebinding.yaml
+++ b/charts/zeebe-cluster-helm/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "zeebe-cluster.names.broker" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
+  annotations:
+    {{- toYaml  .Values.annotations | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "zeebe-cluster.names.broker" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "zeebe-cluster.names.broker" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/zeebe-cluster-helm/templates/serviceaccount.yaml
+++ b/charts/zeebe-cluster-helm/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "zeebe-cluster.names.broker" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
+  annotations:
+    {{- toYaml  .Values.annotations | nindent 4 }}
+{{- end -}}

--- a/charts/zeebe-cluster-helm/templates/statefulset.yaml
+++ b/charts/zeebe-cluster-helm/templates/statefulset.yaml
@@ -110,7 +110,7 @@ spec:
         - name: exporters
           mountPath: /exporters
         securityContext:
-          {{ toYaml .Values.podSecurityContext | indent 12 | trim }}
+          {{ toYaml .Values.podSecurityContext | indent 10 | trim }}
       volumes:
         {{- if or .Values.zeebeCfg .Values.log4j2 }}
       - name: config-broker
@@ -134,6 +134,13 @@ spec:
 {{- end }}
 {{- with .Values.tolerations }}
       tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.serviceAccount.create}}
+      serviceAccountName: {{ include "zeebe-cluster.names.broker" . }}
+{{- end }}
+{{- with .Values.securityContext }}
+      securityContext:
 {{ toYaml . | indent 8 }}
 {{- end }}
   volumeClaimTemplates:

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -93,6 +93,22 @@ podDisruptionBudget:
   minAvailable:
   maxUnavailable: 1
 
+securityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  fsGroup: 0
+podSecurityContext:
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+serviceAccount:
+  create: true
+rbac:
+  enabled: true
+  pspEnabled: false
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -32,6 +32,21 @@ gateway:
     minAvailable: 1
     maxUnavailable:
   resources:  {}
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+  podSecurityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  serviceAccount:
+    create: true
+  rbac:
+    enabled: true
+    pspEnabled: false
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
In order to deploy to EKS, we need to create a custom PodSecurityPolicy that allows Zeebe to run as root and use PVC's on the broker. To actually use a PSP, we also need to create a few extra resources: service account, role, and rolebinding.

I tried to follow the existing chart standards - i.e., use the same set of labels / names / variable structure.

The default rendered output does change and is only backwards compatible by adjusting the values.yaml file. If we prefer, I can adjust those defaults so there is no change - it just means we override things more in https://github.com/ezcater/zeebe-kubernetes. That might make it easier to contribute this to upstream at some point.

You can see the impact of this change here: https://github.com/ezcater/zeebe-kubernetes/pull/91.