### PR TITLE
Changes from Camunda from v0.26 to v1.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.tgz
 *.lock
+.idea

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,6 @@
 approvers:
 - zelldon
-- zelldon
 - npepinpe  
 reviewers:
-- zelldon
 - npepinpe 
 - zelldon

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,8 @@
 approvers:
-- salaboy
+- zelldon
 - zelldon
 - npepinpe  
 reviewers:
-- salaboy
+- zelldon
 - npepinpe 
 - zelldon

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,6 @@
 aliases:
-- salaboy
+- zelldon
 best-approvers:
-- salaboy
+- zelldon
 best-reviewers:
-- salaboy
+- zelldon

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This functionality is in beta and is subject to change. The design and code is l
 ## Requirements
 
 * [Helm](https://helm.sh/) >= 3.x + 
-* Kubernetes >= 1.17+
+* Kubernetes >= 1.18+
 * Minimum cluster requirements include the following to run this chart with default settings. All of these settings are configurable.
   * Three Kubernetes nodes to respect the default "hard" affinity settings
   * 1GB of RAM for the JVM heap
@@ -22,7 +22,7 @@ This functionality is in beta and is subject to change. The design and code is l
 * Install it
 
   ```shell
-  helm install --name zeebe-cluster-helm zeebe/zeebe-cluster-helm
+  helm install zb zeebe/zeebe-cluster-helm
   ```
 
  ## Configuration

--- a/README.md
+++ b/README.md
@@ -132,3 +132,36 @@ elasticsearch:
 kibana:
   enabled: false
 ```
+
+## Development
+
+For development purpose you might want to deploy and test the charts without creating a new release. In order to do this you can run the following:
+
+```sh
+ helm install <RELEASENAME> charts/zeebe-cluster-helm/
+```
+
+If you see errors like:
+
+```sh
+Error: found in Chart.yaml, but missing in charts/ directory: elasticsearch, kibana, kube-prometheus-stack
+```
+
+Then you need to download the depenencies first. You can do this via:
+
+```sh
+$ helm dependency update charts/zeebe-cluster-helm/
+Getting updates for unmanaged Helm repositories...
+...Successfully got an update from the "https://helm.elastic.co" chart repository
+...Successfully got an update from the "https://helm.elastic.co" chart repository
+...Successfully got an update from the "https://prometheus-community.github.io/helm-charts" chart repository
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "zeebe" chart repository
+...Successfully got an update from the "stable" chart repository
+Update Complete. ⎈Happy Helming!⎈
+Saving 3 charts
+Downloading elasticsearch from repo https://helm.elastic.co
+Downloading kibana from repo https://helm.elastic.co
+Downloading kube-prometheus-stack from repo https://prometheus-community.github.io/helm-charts
+Deleting outdated charts
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Community Extension](https://img.shields.io/badge/Community%20Extension-An%20open%20source%20community%20maintained%20project-FF4700)](https://github.com/camunda-community-hub/community)[![Lifecycle: Incubating](https://img.shields.io/badge/Lifecycle-Incubating-blue)](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md#incubating-)
+[![Community Extension](https://img.shields.io/badge/Community%20Extension-An%20open%20source%20community%20maintained%20project-FF4700)](https://github.com/camunda-community-hub/community)[![Lifecycle: Incubating](https://img.shields.io/badge/Lifecycle-Incubating-blue)](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md#incubating-)[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # Zeebe Cluster Helm Chart
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# [MERGED INTO MONO REPO](https://github.com/camunda-community-hub/camunda-cloud-helm)
+
+----------------------------------
+
 [![Community Extension](https://img.shields.io/badge/Community%20Extension-An%20open%20source%20community%20maintained%20project-FF4700)](https://github.com/camunda-community-hub/community)[![Lifecycle: Incubating](https://img.shields.io/badge/Lifecycle-Incubating-blue)](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md#incubating-)[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # Zeebe Cluster Helm Chart

--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.0.0-alpha7"
+appVersion: "1.0.0-rc1"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster-helm
 type: application

--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.0.0-rc1"
+appVersion: "1.0.0"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster-helm
 type: application

--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -3,16 +3,16 @@ appVersion: "1.1.2"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster-helm
 type: application
-version: 0.1.0-SNAPSHOT
+version: 1.1.2-SNAPSHOT
 icon: https://zeebe.io/img/zeebe-logo.png
 dependencies:
 - name: elasticsearch
   repository: "https://helm.elastic.co"
-  version: 7.5.1
+  version: 7.13.2
   condition: "elasticsearch.enabled"
 - name: kibana
   repository: "https://helm.elastic.co" 
-  version: 7.5.1
+  version: 7.13.2
   condition: "kibana.enabled"
 - name: kube-prometheus-stack
   repository: "https://prometheus-community.github.io/helm-charts"

--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.26.1"
+appVersion: "1.0.0-alpha5"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster-helm
 type: application

--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.0.0-alpha5"
+appVersion: "1.0.0-alpha7"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster-helm
 type: application

--- a/charts/zeebe-cluster-helm/templates/statefulset.yaml
+++ b/charts/zeebe-cluster-helm/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           value: "false"
         {{- if not .Values.global.elasticsearch.disableExporter }}
         - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
-          value: "io.zeebe.exporter.ElasticsearchExporter"
+          value: "io.camunda.zeebe.exporter.ElasticsearchExporter"
         - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL
           value: "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
         {{- end }}

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: camunda/zeebe
-  tag: 1.0.0-alpha7
+  tag: 1.0.0-rc1
   pullPolicy: IfNotPresent
 
 clusterSize: "3"

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: camunda/zeebe
-  tag: 1.0.0-rc1
+  tag: 1.0.0
   pullPolicy: IfNotPresent
 
 clusterSize: "3"

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: camunda/zeebe
-  tag: 1.0.0-alpha5
+  tag: 1.0.0-alpha7
   pullPolicy: IfNotPresent
 
 clusterSize: "3"

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: camunda/zeebe
-  tag: 0.26.1
+  tag: 1.0.0-alpha5
   pullPolicy: IfNotPresent
 
 clusterSize: "3"

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -35,11 +35,11 @@ gateway:
 
 elasticsearch:
   enabled: true
-  imageTag: 7.12.1
+  imageTag: 7.13.2
 
 kibana:
   enabled: false
-  imageTag: 7.12.1
+  imageTag: 7.13.2
 
 prometheus:
   enabled: false


### PR DESCRIPTION
The [upstream repo](https://github.com/camunda-community-hub/zeebe-cluster-helm) was merged into a [monorepo](https://github.com/camunda-community-hub/camunda-cloud-helm) after Zeebe v1.1.2 -- this PR gets us across the v1 gap and at least as far as that. We'll look at the monorepo next and put up a different PR for those changes.

EDIT: Note, because there were merge conflicts on this PR, we've pulled the changes here into a separate branch and fixed the commits: #9 